### PR TITLE
Singleton desteği, Request sınıfı ve Middleware Interrupt

### DIFF
--- a/App/bootstrap.php
+++ b/App/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+use \Prototurk\Core\Request;
+
+/**
+ * İsteği bekleterek middleware'leri çalıştıralım.
+*/
+Request::setMiddlewares([
+//	\Prototurk\Middlewares\TestMiddleware::class,
+]);

--- a/App/bootstrap.php
+++ b/App/bootstrap.php
@@ -3,14 +3,17 @@ use \Prototurk\Core\{Request, Route};
 
 
 require __DIR__ . '/routes/web.php';
-
 Route::prefix('/api');
 require __DIR__ . '/routes/api.php';
 Route::$prefix = '';
 
 /**
  * İsteği bekleterek middleware'leri çalıştıralım.
+ *
+ * TestMiddleware satırının yorum'u kaldırıldığında interrupt() metodu çalışır
+ * ve url'de test parametresinin olup olmadığını kontrol eder eğer varsa İstek
+ * devam ettirilir. Eğer yoksa Exception fırlatılır.
 */
 Request::setMiddlewares([
-//	\Prototurk\Middlewares\TestMiddleware::class,
+	\Prototurk\Middlewares\TestMiddleware::class,
 ]);

--- a/App/bootstrap.php
+++ b/App/bootstrap.php
@@ -1,5 +1,12 @@
 <?php
-use \Prototurk\Core\Request;
+use \Prototurk\Core\{Request, Route};
+
+
+require __DIR__ . '/routes/web.php';
+
+Route::prefix('/api');
+require __DIR__ . '/routes/api.php';
+Route::$prefix = '';
 
 /**
  * İsteği bekleterek middleware'leri çalıştıralım.

--- a/Core/App.php
+++ b/Core/App.php
@@ -5,6 +5,9 @@ namespace Prototurk\Core;
 class App
 {
 
+	/**
+	 * @var Request $request    Tarayıcıdan gönderilen istek nesnesini barındırır.
+	*/
 	public Request $request;
 
     public function __construct()

--- a/Core/App.php
+++ b/Core/App.php
@@ -5,9 +5,11 @@ namespace Prototurk\Core;
 class App
 {
 
+	public Request $request;
+
     public function __construct()
     {
-
+		$this->request = Request::getInstance();
     }
 
 }

--- a/Core/Helpers/Singleton.php
+++ b/Core/Helpers/Singleton.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Prototurk\Core\Helpers;
+use Exception;
+
+/**
+ * @class Singleton
+ * @package Prototurk\Core\Helpers
+ * @author Utku Korkmaz <uutkukorkmaz@gmail.com>
+*/
+abstract class Singleton
+{
+	/**
+	 * @var array $instances  Tüm Singleton türevi sınıfların varlıklarını barındırır
+	*/
+	private static array $instances = [];
+
+	/**
+	 * Singleton constructor
+	 *
+	 * Singleton olmasını istediğimiz nesneleri new ClassName(); şeklinde
+	 * çağıramamamız gerektiği için, türevi sınıfların construct metodları
+	 * protected olmak zorundadır.
+	*/
+	protected function __construct(){}
+
+	protected function __clone(){}
+
+	/**
+	 * Serialize ve unserialize işlemlerinin sonucunda yeni bir varlık oluşacağından
+	 * olası conflict'leri engellemek için __wakeup metodunda basitçe hata
+	 * gösteriyoruz.
+	 *
+	 * @throws Exception
+	*/
+	public function __wakeup(){
+		throw new Exception("");
+	}
+
+	/**
+	 * Singleton türevi olan sınıfların yaratılan tek varlığına erişebilmek için
+	 * varlığı geri döndüreceğimiz methodumuz.
+	 *
+	 * method içinde kullanılan 'static' terimi türev sınıfın psr-4 karşılığına
+	 * denk gelmektedir
+	 *
+	 * @return static
+	*/
+	public static function getInstance(){
+		$instance = static::class;
+		/**
+		 * Türev varlık daha önceden yaratılmış mı?
+		*/
+		if(!array_key_exists($instance,self::$instances)){
+			self::$instances[$instance] = new static();
+		}
+
+		return self::$instances[$instance];
+	}
+
+
+}

--- a/Core/Middleware.php
+++ b/Core/Middleware.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Prototurk\Core;
+
+
+abstract class Middleware
+{
+
+	abstract function interrupt();
+
+}

--- a/Core/Middleware.php
+++ b/Core/Middleware.php
@@ -3,10 +3,18 @@
 
 namespace Prototurk\Core;
 
-
+/**
+ * @class abstract Middleware
+ * @package Prototurk\Core
+ * @author Utku Korkmaz <uutkukorkmaz@gmail.com>
+*/
 abstract class Middleware
 {
-
+	/**
+	 * İstek duraklatıldığında türev sınıfların bu methodu çalışır.
+	 *
+	 * İstek return ile devam ettirilir; Exception fırlatılarak sonlandırılır.
+	*/
 	abstract function interrupt();
 
 }

--- a/Core/Request.php
+++ b/Core/Request.php
@@ -3,8 +3,15 @@
 
 namespace Prototurk\Core;
 
+use Prototurk\Core\Helpers\Singleton;
 
-class Request extends Helpers\Singleton
+/**
+ * @class Request
+ * @extends Prototurk\Core\Helpers\Singleton
+ * @package Prototurk\Core
+ * @author Utku Korkmaz <uutkukorkmaz@gmail.com>
+*/
+class Request extends Singleton
 {
 	/**
 	 * @var string $uri İstek gönderilen URL uzantısını barındırır
@@ -38,6 +45,8 @@ class Request extends Helpers\Singleton
 	}
 
 	/**
+	 * İstek metodunu alır
+	 *
 	 * @return string
 	 */
 	public static function getMethod(): string
@@ -46,6 +55,8 @@ class Request extends Helpers\Singleton
 	}
 
 	/**
+	 * İstek URL'ini alır
+	 *
 	 * @return string
 	 */
 	public static function getUrl(): string
@@ -53,17 +64,33 @@ class Request extends Helpers\Singleton
 		return self::$uri;
 	}
 
-	protected static function parse()
+	/**
+	 * İstek URL'ini işler
+	 *
+	 * @return string
+	 */
+	protected static function parse(): string
 	{
 		return self::$uri = str_replace($_ENV['BASE_PATH'], null, $_SERVER['REQUEST_URI']);
 	}
 
-	protected static function middleware($middleware)
+	/**
+	 * Bir middleware tanımlar
+	 *
+	 * @param string $middleware
+	 * @return void
+	 */
+	protected static function middleware(string $middleware): void
 	{
 		self::$middlewares[] = new $middleware();
 	}
 
-	public function dispatch()
+	/**
+	 * Tanımlanan middleware'ler ile isteği duraklatır ve tanımlanan interrupt'ları çağırır.
+	 *
+	 * @return void
+	 */
+	public function dispatch(): void
 	{
 		if (count(self::$middlewares)) {
 			foreach (self::$middlewares as $interrupt) {
@@ -72,15 +99,27 @@ class Request extends Helpers\Singleton
 		}
 	}
 
-	public static function setMiddlewares(array $middlewares)
+	/**
+	 * İsteği interrupt etmesini istediğimiz middleware'leri tanımlar.
+	 *
+	 * @return void
+	*/
+	public static function setMiddlewares(array $middlewares): void
 	{
 		foreach ($middlewares as $middleware) {
 			self::middleware($middleware);
 		}
 	}
 
-	public function input($name = '')
+	/**
+	 * İstek metoduna ait gönderilen verileri döndürür
+	 *
+	 * @param string|null $name
+	 * @return mixed
+	 */
+	public function input(?string $name = null)
 	{
+
 		switch (self::getMethod()) {
 			case "put":
 			case "delete":
@@ -88,9 +127,17 @@ class Request extends Helpers\Singleton
 			default:
 				return false;
 			case "get":
-				return $_GET[$name] ?? false;
+				if (!is_null($name)) {
+					return isset($_GET[$name]) ? $_GET[$name] : false;
+				} else {
+					return $_GET;
+				}
 			case "post":
-				return $_POST[$name] ?? false;
+				if (!is_null($name)) {
+					return $_POST[$name] ?? false;
+				} else {
+					return $_POST;
+				}
 		}
 	}
 

--- a/Core/Request.php
+++ b/Core/Request.php
@@ -1,0 +1,97 @@
+<?php
+
+
+namespace Prototurk\Core;
+
+
+class Request extends Helpers\Singleton
+{
+	/**
+	 * @var string $uri İstek gönderilen URL uzantısını barındırır
+	 */
+	public static string $uri;
+	/**
+	 * @var string $query HTTP GET query değerlerini barındırır
+	 */
+	public static string $query;
+	/**
+	 * @var string $method İstek metodunu barındırır
+	 */
+	public static string $method;
+
+	/**
+	 * @var array $middlewares Interrupt sınıflarını barındırır
+	 */
+	public static array $middlewares = [];
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function __construct()
+	{
+		parent::__construct();
+		self::parse();
+		$url = explode('?', self::getUrl());
+		self::$uri = $url[0];
+		self::$query = $url[1] ?? "";
+		self::$method = self::getMethod();
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function getMethod(): string
+	{
+		return strtolower($_SERVER['REQUEST_METHOD']);
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function getUrl(): string
+	{
+		return self::$uri;
+	}
+
+	protected static function parse()
+	{
+		return self::$uri = str_replace($_ENV['BASE_PATH'], null, $_SERVER['REQUEST_URI']);
+	}
+
+	protected static function middleware($middleware)
+	{
+		self::$middlewares[] = new $middleware();
+	}
+
+	public function dispatch()
+	{
+		if (count(self::$middlewares)) {
+			foreach (self::$middlewares as $interrupt) {
+				$interrupt->interrupt();
+			}
+		}
+	}
+
+	public static function setMiddlewares(array $middlewares)
+	{
+		foreach ($middlewares as $middleware) {
+			self::middleware($middleware);
+		}
+	}
+
+	public function input($name = '')
+	{
+		switch (self::getMethod()) {
+			case "put":
+			case "delete":
+			case "patch":
+			default:
+				return false;
+			case "get":
+				return $_GET[$name] ?? false;
+			case "post":
+				return $_POST[$name] ?? false;
+		}
+	}
+
+}

--- a/Core/Route.php
+++ b/Core/Route.php
@@ -42,8 +42,11 @@ class Route
 
     public static function dispatch()
     {
-        $url = self::getUrl();
-        $method = self::getMethod();
+
+	    $url = Request::getUrl();
+	    echo $url;
+        $method = Request::getMethod();
+
         foreach (self::$routes[$method] as $path => $props) {
 
             foreach (self::$patterns as $key => $pattern) {
@@ -61,7 +64,7 @@ class Route
                 } else {
 
                     $callback = $props['callback'];
-
+					request()->dispatch();
                     if (is_callable($callback)) {
                         echo call_user_func_array($callback, $params);
                     } elseif (is_string($callback)) {
@@ -88,21 +91,6 @@ class Route
         }
     }
 
-    /**
-     * @return string
-     */
-    public static function getMethod(): string
-    {
-        return strtolower($_SERVER['REQUEST_METHOD']);
-    }
-
-    /**
-     * @return string
-     */
-    public static function getUrl(): string
-    {
-        return str_replace(getenv('BASE_PATH'), null, $_SERVER['REQUEST_URI']);
-    }
 
     public function name(string $name): void
     {

--- a/Core/Route.php
+++ b/Core/Route.php
@@ -44,7 +44,6 @@ class Route
     {
 
 	    $url = Request::getUrl();
-	    echo $url;
         $method = Request::getMethod();
 
         foreach (self::$routes[$method] as $path => $props) {

--- a/Core/helpers.php
+++ b/Core/helpers.php
@@ -38,3 +38,9 @@ function model(string $name){
     $name = '\Prototurk\App\Models\\' . $name;
     return new $name();
 }
+/**
+ * @return \Prototurk\Core\Request
+*/
+function request(){
+	return \Prototurk\Core\Request::getInstance();
+}

--- a/Middlewares/TestMiddleware.php
+++ b/Middlewares/TestMiddleware.php
@@ -10,7 +10,7 @@ class TestMiddleware extends Middleware
 
 	function interrupt()
 	{
-		if(request()->input('test') || request()->input('test')==""){
+		if(request()->input('test') !== false){
 			return;
 		}
 		throw new \Exception('Test değeri gönderilmedi!');

--- a/Middlewares/TestMiddleware.php
+++ b/Middlewares/TestMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Prototurk\Middlewares;
+
+use Prototurk\Core\Middleware;
+
+class TestMiddleware extends Middleware
+{
+
+	function interrupt()
+	{
+		if(request()->input('test') || request()->input('test')==""){
+			return;
+		}
+		throw new \Exception('Test değeri gönderilmedi!');
+	}
+}

--- a/index.php
+++ b/index.php
@@ -12,12 +12,7 @@ require_once __DIR__ . '/App/bootstrap.php';
 
 $dotenv = Dotenv\Dotenv::createUnsafeImmutable(__DIR__);
 $dotenv->load();
+
 $app = new App();
-
-require __DIR__ . '/App/routes/web.php';
-
-Route::prefix('/api');
-require __DIR__ . '/App/routes/api.php';
-Route::$prefix = '';
 
 Route::dispatch();

--- a/index.php
+++ b/index.php
@@ -7,10 +7,12 @@ require __DIR__ . '/vendor/autoload.php';
 
 use \Prototurk\Core\{App, Route};
 
-$app = new \Prototurk\Core\App();
+require_once __DIR__ . '/App/bootstrap.php';
+
 
 $dotenv = Dotenv\Dotenv::createUnsafeImmutable(__DIR__);
 $dotenv->load();
+$app = new App();
 
 require __DIR__ . '/App/routes/web.php';
 


### PR DESCRIPTION
Selamlar,
Proje'ye faydalı olacağını düşündüğüm bir iki ufak ekleme yaptım naçizane kendi çapımda. Yazdığım methodlara ve sınıflara PHPDoc açıklamaları ekledim ancak ihtiyaç halinde dökümantasyonunu da çıkarabilirim.

1. **Singleton** ( Prototurk\Core\Helpers\Singleton )
Hemen her nesne yönelimli projede olduğu gibi Prototürk framework'ünde de Singleton'a ihtiyaç duyacağımız _(veritabanı bağlantısı veya loglama işlemleri gibi)_ yerler  olacaktır. Bu ihtiyaca yönelik basit bir singleton abstract'ı oluşturdum.

2. **Request**
İlerleyen aşamalarda isteği yönetmemiz gerekecektir ve bunu Router'da yapıp, kalabalık yaratmak yerine böyle bir sınıfta toplanmasının mantıklı olabileceğini düşündüm. 

3. **Middlewares & Interrupt**
İstek süresince yanıt üretilmeden önce bazı sayfalar bir takım genelleştirilebilecek kontrollere ihtiyaç duyar. Middleware yapısı ile bu ihtiyacı karşılayabiliriz. Örneğin bir TrimInputMiddleware oluşturarak gönderilen verilerin tamamını süzgeçten geçirebiliriz.
